### PR TITLE
Add docker images for database backups

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,42 @@
+name: Build and release images
+
+on:
+  push:
+    branches:
+      - main
+concurrency: build-${{ github.sha }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create SHA tag
+        id: sha_tag
+        run: |
+          tag=$(cut -c 1-7 <<< $GITHUB_SHA)
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+
+      - name: Build images
+        run: |
+          docker build ./images/postgresql-s3-backup/ -t ghcr.io/quiltmc/postgresql-s3-backup:latest
+          docker tag ghcr.io/quiltmc/postgresql-s3-backup:latest ghcr.io/quiltmc/postgresql-s3-backup:${{ steps.sha_tag.outputs.tag }}
+          docker build ./images/mongodb-s3-backup/ -t ghcr.io/quiltmc/mongodb-s3-backup:latest
+          docker tag ghcr.io/quiltmc/mongodb-s3-backup:latest ghcr.io/quiltmc/mongodb-s3-backup:${{ steps.sha_tag.outputs.tag }}
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push images to the registry
+        run: |
+          docker push ghcr.io/quiltmc/postgresql-s3-backup:latest
+          docker push ghcr.io/quiltmc/postgresql-s3-backup:${{ steps.sha_tag.outputs.tag }}
+          docker push ghcr.io/quiltmc/mongodb-s3-backup:latest
+          docker push ghcr.io/quiltmc/mongodb-s3-backup:${{ steps.sha_tag.outputs.tag }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,9 +1,7 @@
 name: Build and release images
 
-on:
-  push:
-    branches:
-      - main
+on: push
+
 concurrency: build-${{ github.sha }}
 
 jobs:
@@ -28,6 +26,7 @@ jobs:
           docker tag ghcr.io/quiltmc/mongodb-s3-backup:latest ghcr.io/quiltmc/mongodb-s3-backup:${{ steps.sha_tag.outputs.tag }}
 
       - name: Login to Github Container Registry
+        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -35,6 +34,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push images to the registry
+        if: github.ref == 'refs/heads/main'
         run: |
           docker push ghcr.io/quiltmc/postgresql-s3-backup:latest
           docker push ghcr.io/quiltmc/postgresql-s3-backup:${{ steps.sha_tag.outputs.tag }}

--- a/charts/cozy/Chart.lock
+++ b/charts/cozy/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 13.16.2
 - name: s3-backups
   repository: file://../s3-backups
-  version: 0.1.2
-digest: sha256:35e069526f02c4c034838e6a6fb7728d2416c747d197563c8870861bb02d605e
-generated: "2023-11-08T13:41:36.999090206-05:00"
+  version: 0.2.0
+digest: sha256:ed55f38f351d0d9cd5a4485e23bd71277408eb0f2362f1cc4ed6d8e49c90384f
+generated: "2024-05-12T02:48:54.590979+02:00"

--- a/charts/cozy/Chart.yaml
+++ b/charts/cozy/Chart.yaml
@@ -4,7 +4,7 @@ name: quilt-cozy
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
 # This is the version number of the application being deployed (purely informational).
 appVersion: '1'
 description: helm chart to deploy the Quilt Cozy Discord bot
@@ -21,5 +21,5 @@ dependencies:
     version: 13.16.2
     repository: https://charts.bitnami.com/bitnami
   - name: s3-backups
-    version: 0.1.2
+    version: 0.2.0
     repository: 'file://../s3-backups'

--- a/charts/cozy/values.yaml
+++ b/charts/cozy/values.yaml
@@ -6,7 +6,8 @@ messageLogs: '839495849116958780,839496251463958548'
 releaseChannels: '832351145073573889,832351173640978472'
 statusChannel: '1009020306280681532'
 
-resources: # cf. https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+# cf. https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+resources:
   limits:
     cpu: 400m
     memory: 924Mi

--- a/charts/forum/Chart.lock
+++ b/charts/forum/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 17.17.1
 - name: s3-backups
   repository: file://../s3-backups
-  version: 0.1.2
-digest: sha256:bd21a581ec07cbb25dc97fce1a753e344c15cc31bb16161bc43bdc34d3924aa3
-generated: "2023-11-08T13:46:26.300506947-05:00"
+  version: 0.2.0
+digest: sha256:6ad85e467301603ce3782e8e81f68932fc399302bc4aa5dad9dea8836cf92ee4
+generated: "2024-05-12T02:49:15.499456+02:00"

--- a/charts/forum/Chart.yaml
+++ b/charts/forum/Chart.yaml
@@ -4,7 +4,7 @@ name: quilt-forum
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 # This is the version number of the Discourse image being deployed (purely informational).
 appVersion: '3.2.1'
 description: helm chart to deploy the Quilt Discourse Forum
@@ -27,5 +27,5 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 17.X.X
   - name: s3-backups
-    version: 0.1.2
+    version: 0.2.0
     repository: 'file://../s3-backups'

--- a/charts/modmail/Chart.lock
+++ b/charts/modmail/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 13.16.2
 - name: s3-backups
   repository: file://../s3-backups
-  version: 0.1.2
-digest: sha256:35e069526f02c4c034838e6a6fb7728d2416c747d197563c8870861bb02d605e
-generated: "2023-11-08T13:43:55.611759705-05:00"
+  version: 0.2.0
+digest: sha256:ed55f38f351d0d9cd5a4485e23bd71277408eb0f2362f1cc4ed6d8e49c90384f
+generated: "2024-05-12T02:51:30.626063+02:00"

--- a/charts/modmail/Chart.yaml
+++ b/charts/modmail/Chart.yaml
@@ -4,7 +4,7 @@ name: quilt-modmail
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
 # This is the version number of the application being deployed (purely informational).
 appVersion: '1'
 description: helm chart to deploy Quilt's Modmail Discord bot
@@ -21,5 +21,5 @@ dependencies:
     version: 13.16.2
     repository: https://charts.bitnami.com/bitnami
   - name: s3-backups
-    version: 0.1.2
+    version: 0.2.0
     repository: 'file://../s3-backups'

--- a/charts/modmail/values.yaml
+++ b/charts/modmail/values.yaml
@@ -13,7 +13,8 @@ viewer:
   port: 80
   oauthClientId: '836548129763098674'
 
-resources: # cf. https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+# cf. https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+resources:
   limits:
     cpu: 400m
     memory: 924Mi

--- a/charts/s3-backups/Chart.lock
+++ b/charts/s3-backups/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mongodb
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.16.2
+digest: sha256:17d8573ce48684adf09ea3684534a85acab1fcbf101d041cdacc65cf87f6c8d3
+generated: "2024-05-12T02:51:37.002346+02:00"

--- a/charts/s3-backups/Chart.yaml
+++ b/charts/s3-backups/Chart.yaml
@@ -4,7 +4,7 @@ name: s3-backups
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 # This is the version number of the application being deployed (purely informational).
 appVersion: '1'
 description: helm chart handling Quilt's backups to an S3

--- a/charts/s3-backups/templates/cronjob.yaml
+++ b/charts/s3-backups/templates/cronjob.yaml
@@ -13,9 +13,9 @@ spec:
           containers:
             - name: backup
               {{- if eq .Values.database.type "mongodb" }}
-              image: ghcr.io/bitofsky/mongodb-awscli-image:v0.0.1
+              image: ghcr.io/quiltmc/mongodb-s3-backup:latest
               {{- else if eq .Values.database.type "postgresql" }}
-              image: osodevops/aws-cli-postgres
+              image: ghcr.io/quiltmc/postgresql-s3-backup:latest
               {{- end }}
               imagePullPolicy: IfNotPresent
               command: ["/bin/sh", "-c"]

--- a/charts/stats/Chart.lock
+++ b/charts/stats/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 12.8.0
 - name: s3-backups
   repository: file://../s3-backups
-  version: 0.1.2
-digest: sha256:822e55f861924ff561d776eacdd1af188b0d92e1e66cd0e70a6a7142295239d9
-generated: "2023-11-08T13:44:38.542968618-05:00"
+  version: 0.2.0
+digest: sha256:48d01dbddab226ed5d1e4166fab44ee771ffbb781cdb5c447d35d67b1901526e
+generated: "2024-05-12T02:51:42.396378+02:00"

--- a/charts/stats/Chart.yaml
+++ b/charts/stats/Chart.yaml
@@ -4,7 +4,7 @@ name: quilt-stats
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
 # This is the version number of the application being deployed (purely informational).
 appVersion: '1'
 description: helm chart to deploy Quilt's Stats Discord bot
@@ -21,5 +21,5 @@ dependencies:
     version: 12.8.0
     repository: https://charts.bitnami.com/bitnami
   - name: s3-backups
-    version: 0.1.2
+    version: 0.2.0
     repository: 'file://../s3-backups'

--- a/charts/stats/values.yaml
+++ b/charts/stats/values.yaml
@@ -9,7 +9,8 @@ metabase:
   url: stats.quiltmc.org
   port: 3000
 
-resources: # cf. https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+# cf. https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+resources:
   limits:
     cpu: 400m
     memory: 924Mi

--- a/images/mongodb-s3-backup/Dockerfile
+++ b/images/mongodb-s3-backup/Dockerfile
@@ -2,12 +2,14 @@ FROM ubuntu:22.04
 
 WORKDIR /dump
 
-RUN wget -qO- https://www.mongodb.org/static/pgp/server-7.0.asc | tee /etc/apt/trusted.gpg.d/server-7.0.asc \
-    && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list \
+RUN apt update \
     && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
-    && apt update \
-    && apt-get install -y tzdata gnupg wget mongodb-mongosh curl unzip \
+    && apt-get install -y tzdata gnupg wget curl unzip \
     && dpkg-reconfigure --frontend noninteractive tzdata \
+    && wget -qO- https://www.mongodb.org/static/pgp/server-7.0.asc | tee /etc/apt/trusted.gpg.d/server-7.0.asc \
+    && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list \
+    && apt update \
+    && apt-get install -y mongodb-mongosh \
     && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
     && ./aws/install \

--- a/images/mongodb-s3-backup/Dockerfile
+++ b/images/mongodb-s3-backup/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:22.04
+
+WORKDIR /dump
+
+RUN wget -qO- https://www.mongodb.org/static/pgp/server-7.0.asc | tee /etc/apt/trusted.gpg.d/server-7.0.asc \
+    && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list \
+    && apt update \
+    && apt-get install -y tzdata gnupg wget mongodb-mongosh curl unzip \
+    && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
+    && dpkg-reconfigure --frontend noninteractive tzdata \
+    && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install \
+    && rm -rf awscliv2.zip aws \
+    && aws --version
+
+CMD ["bash"]

--- a/images/mongodb-s3-backup/Dockerfile
+++ b/images/mongodb-s3-backup/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /dump
 
 RUN wget -qO- https://www.mongodb.org/static/pgp/server-7.0.asc | tee /etc/apt/trusted.gpg.d/server-7.0.asc \
     && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list \
+    && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
     && apt update \
     && apt-get install -y tzdata gnupg wget mongodb-mongosh curl unzip \
-    && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
     && dpkg-reconfigure --frontend noninteractive tzdata \
     && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \

--- a/images/postgresql-s3-backup/Dockerfile
+++ b/images/postgresql-s3-backup/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:22.04
+
+WORKDIR /dump
+
+RUN apt update \
+    && apt-get install -y tzdata postgresql-client curl unzip \
+    && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
+    && dpkg-reconfigure --frontend noninteractive tzdata \
+    && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip awscliv2.zip \
+    && ./aws/install \
+    && rm -rf awscliv2.zip aws \
+    && aws --version
+
+CMD ["bash"]

--- a/images/postgresql-s3-backup/Dockerfile
+++ b/images/postgresql-s3-backup/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:22.04
 WORKDIR /dump
 
 RUN apt update \
-    && apt-get install -y tzdata postgresql-client curl unzip \
     && ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
+    && apt-get install -y tzdata postgresql-client curl unzip \
     && dpkg-reconfigure --frontend noninteractive tzdata \
     && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \


### PR DESCRIPTION
The images we were using for our database backups until this point were were either outdated or unreliable. This PR thus adds manifests for simple Postgresql+AWS CLI and MongoDB+AWS CLI docker images, as well as the GitHub workflow to build and push them to our container registry.