### PR TITLE
Set up ArgoCD

### DIFF
--- a/argocd/IngressRoute.yaml
+++ b/argocd/IngressRoute.yaml
@@ -1,0 +1,26 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: argocd-server
+  namespace: argocd
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`argocd.quiltmc.net`)
+      priority: 10
+      services:
+        - name: argocd-server
+          port: 80
+    # Note: this rule is currently unused as Cloudflare does not support Grpc on tunnels
+    # (https://developers.cloudflare.com/network/grpc-connections/#limitations)
+    - kind: Rule
+      match: Host(`argocd.quiltmc.net`) && Headers(`Content-Type`, `application/grpc`)
+      priority: 11
+      services:
+        - name: argocd-server
+          port: 80
+          scheme: h2c
+  tls:
+    certResolver: default


### PR DESCRIPTION
Our setup until now involved a lot of manual updates through the command-line, which required direct intervention from an infrastructure member, was hard to monitor, and rather error-prone. We could have set up a workflow to run the `helm install` command for us, but this would have required exposing our servers to said workflow, and would only be a half-solution to the aforementioned pain points.

ArgoCD lets us run updates based on this repository from within the cluster, and gives us a nice interface from which to monitor and interact with our resources. Furthermore, it allows us to add access to other teams in our GitHub organization, so they can themselves run basic maintainance (notably, restarts).

Most of the work to set up ArgoCD being done outside this repository, this PR adds only the manifest for an ingress route to ArgoCD's dashboard. This manifest is not strictly related to the Helm charts we distribute, but I figured it made little sense to create a whole repository to host it.